### PR TITLE
StringInputFilter 개선

### DIFF
--- a/ext/src/main/java/net/spooncast/ext/collections/ListExt.kt
+++ b/ext/src/main/java/net/spooncast/ext/collections/ListExt.kt
@@ -34,3 +34,5 @@ fun <T> List<T>.replace(
 inline fun <T> Collection<T>.has(predicate: (T) -> Boolean): Boolean {
     return firstOrNull(predicate) != null
 }
+
+fun List<String>.containsIgnoreCase(element: String): Boolean = this.any { it.equals(element, true) }

--- a/ext/src/main/java/net/spooncast/ext/string/StringInputFilter.kt
+++ b/ext/src/main/java/net/spooncast/ext/string/StringInputFilter.kt
@@ -14,10 +14,13 @@ class StringInputFilter(
         dstart: Int,
         dend: Int
     ): CharSequence {
-        return if (source.matches(regex)) {
-            source
-        } else {
-            ""
+        val filteredString = StringBuilder()
+        for (i in start until end) {
+            val char = source.getOrNull(i) ?: return ""
+            if (char.toString().matches(regex)) {
+                filteredString.append(char)
+            }
         }
+        return filteredString
     }
 }

--- a/ext/src/main/java/net/spooncast/ext/string/StringInputFilter.kt
+++ b/ext/src/main/java/net/spooncast/ext/string/StringInputFilter.kt
@@ -4,7 +4,7 @@ import android.text.InputFilter
 import android.text.Spanned
 
 class StringInputFilter(
-    val regex: Regex
+    private val regex: Regex
 ): InputFilter {
     override fun filter(
         source: CharSequence,

--- a/ext/src/main/java/net/spooncast/ext/string/StringInputFilter.kt
+++ b/ext/src/main/java/net/spooncast/ext/string/StringInputFilter.kt
@@ -1,0 +1,23 @@
+package net.spooncast.ext.string
+
+import android.text.InputFilter
+import android.text.Spanned
+
+class StringInputFilter(
+    val regex: Regex
+): InputFilter {
+    override fun filter(
+        source: CharSequence,
+        start: Int,
+        end: Int,
+        dest: Spanned?,
+        dstart: Int,
+        dend: Int
+    ): CharSequence {
+        return if (source.matches(regex)) {
+            source
+        } else {
+            ""
+        }
+    }
+}


### PR DESCRIPTION
[ 이슈 사항 ]
- Given : 영어(대/소문자), 숫자, 띄어쓰기, 언더바를 Regex로 설정한 경우
- When : 한글 자모 입력 후, 바로 숫자를 입력하면
**Then : 해당 숫자가 입력된다.**
**Actual : 해당 숫자가 입력되지 않는다.**

[ 개선 내역 ]
- "ㅎ0, ㅗ0, ㅛ0"과 같이 모든 텍스트가 전달되는 것을 확인했습니다. 이에 각 Character를 확인하여 유효한 것만 입력되도록 개선합니다.