### PR TITLE
Flow 확장 함수 throttleFirst 추가 (이슈 개선)

### DIFF
--- a/ext/src/main/java/net/spooncast/ext/flow/FlowExt.kt
+++ b/ext/src/main/java/net/spooncast/ext/flow/FlowExt.kt
@@ -1,0 +1,17 @@
+package net.spooncast.ext.flow
+
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
+
+fun <T> Flow<T>.throttleFirst(
+    timeoutMillis: Long
+) = flow {
+    var emitTime = 0L
+    collect { upStream ->
+        val currentTime = System.currentTimeMillis()
+        if (currentTime - emitTime > timeoutMillis) {
+            emitTime = currentTime
+            emit(upStream)
+        }
+    }
+}

--- a/ext/src/main/java/net/spooncast/ext/flow/FlowExt.kt
+++ b/ext/src/main/java/net/spooncast/ext/flow/FlowExt.kt
@@ -4,14 +4,14 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
 
 fun <T> Flow<T>.throttleFirst(
-    timeoutMillis: Long
+    timeoutMillis: Long,
+    currentTimeMillis: Long = System.currentTimeMillis()
 ) = flow {
-    var emitTime = 0L
-    collect { upStream ->
-        val currentTime = System.currentTimeMillis()
-        if (currentTime - emitTime > timeoutMillis) {
-            emitTime = currentTime
-            emit(upStream)
+    var lastEmitTimeMillis = 0L
+    collect {
+        if (currentTimeMillis - lastEmitTimeMillis > timeoutMillis) {
+            lastEmitTimeMillis = currentTimeMillis
+            emit(it)
         }
     }
 }

--- a/ext/src/main/java/net/spooncast/ext/flow/FlowExt.kt
+++ b/ext/src/main/java/net/spooncast/ext/flow/FlowExt.kt
@@ -4,11 +4,11 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
 
 fun <T> Flow<T>.throttleFirst(
-    timeoutMillis: Long,
-    currentTimeMillis: Long = System.currentTimeMillis()
+    timeoutMillis: Long
 ) = flow {
     var lastEmitTimeMillis = 0L
     collect {
+        val currentTimeMillis = System.currentTimeMillis()
         if (currentTimeMillis - lastEmitTimeMillis > timeoutMillis) {
             lastEmitTimeMillis = currentTimeMillis
             emit(it)


### PR DESCRIPTION
flow로 넘어오는 데이터의 emit 여부를 '현재 시간과 마지막 emit 시간을 비교'하여 결정하고 있습니다. 파라미터로 현재 시간을 설정하면, 해당 확장 함수를 선언한 시점이 현재 시간으로 결정되어 동작하지 않아 이를 개선합니다.

```
fun <T> Flow<T>.throttleFirst(
    timeoutMillis: Long,
    currentTimeMillis: Long = System.currentTimeMillis()
) = flow {
    var lastEmitTimeMillis = 0L
    collect {
        Log.d("seop", "current : ${currentTimeMillis}, last : ${lastEmitTimeMillis}, isRun : ${currentTimeMillis - lastEmitTimeMillis > timeoutMillis}")

        if (currentTimeMillis - lastEmitTimeMillis > timeoutMillis) {
            lastEmitTimeMillis = currentTimeMillis
            emit(it)
        }
    }
}

2023-11-15 14:37:01.795 22112-22112 seop                    co.spoonme                           D  current : 1700026612715, last : 0, isRun : true
2023-11-15 14:37:12.689 22112-22112 seop                    co.spoonme                           D  Send event
2023-11-15 14:37:12.693 22112-22112 seop                    co.spoonme                           D  current : 1700026612715, last : 1700026612715, isRun : false
2023-11-15 14:37:16.842 22112-22112 seop                    co.spoonme                           D  Send event
2023-11-15 14:37:16.856 22112-22112 seop                    co.spoonme                           D  current : 1700026612715, last : 1700026612715, isRun : false
```